### PR TITLE
Changes to MouseInputManager

### DIFF
--- a/src/input/MouseInputManager.ts
+++ b/src/input/MouseInputManager.ts
@@ -726,12 +726,12 @@ module cc.input {
                 target.addEventListener("touchend", touchEnd, false);
             } else {
 
-                window.addEventListener('mouseup',  mouseUp,    false);
-                window.addEventListener('mousedown',mouseDown,  false);
-                window.addEventListener('mouseover',mouseOver,  false);
-                window.addEventListener('mouseout', mouseOut,   false);
-                window.addEventListener('mousemove',mouseMove,  false);
-                window.addEventListener('dblclick', doubleClick,false);
+                target.addEventListener('mouseup',  mouseUp,    false);
+                target.addEventListener('mousedown',mouseDown,  false);
+                target.addEventListener('mouseover',mouseOver,  false);
+                target.addEventListener('mouseout', mouseOut,   false);
+                target.addEventListener('mousemove',mouseMove,  false);
+                target.addEventListener('dblclick', doubleClick,false);
             }
         }
 


### PR DESCRIPTION
to provide the chance to use cocos2d-html as game-engine in Mixed applications (cocos2d scenes and other GUI part based on HTML elements above scenes for example) add addEventListener only to the game canvas not to window
